### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -60,7 +60,7 @@ pub fn send_pings(
             } else {
                 Ok(0)
             } {
-                Err(e) => log::error!("failed to send ping to {:.?}: {}", *addr , e),
+                Err(e) => log::error!("failed to send ping to {:?}: {}", *addr , e),
                 _=> {}
             }
             *seen = false;


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.